### PR TITLE
docs: Update documentation to reflect current asset counts after merge

### DIFF
--- a/.github/ASSETS.md
+++ b/.github/ASSETS.md
@@ -11,7 +11,7 @@
 | **Skills** | 3 | `.github/skills/*/SKILL.md` | `name`, `description` |
 | **Agents** | 6 | `.github/agents/*.agent.md` | `description` |
 | **Instructions** | 9 | `.github/instructions/*.instructions.md` | `applyTo` |
-| **Prompts** | 14 | `.github/prompts/*.prompt.md` | - |
+| **Prompts** | 15 | `.github/prompts/*.prompt.md` | - |
 | **Templates** | 7 | `.github/templates/*.template.md` | - |
 
 ---
@@ -218,9 +218,9 @@ Instructions ↔ Prompts (paired execution)
 | **Skills** | 3 |
 | **Agents** | 6 |
 | **Instructions** | 9 |
-| **Prompts** | 14 |
+| **Prompts** | 15 |
 | **Templates** | 7 |
-| **Total** | 39 |
+| **Total** | 40 |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Generation and quality patterns:
 - `RepoReview` - Repository analysis
 - `WorkflowValidation` - Workflow integrity
 
-### Prompts (14 total)
+### Prompts (15 total)
 Slash commands for user interaction:
 
 **Core Workflows:**
@@ -178,9 +178,9 @@ COMPLETE
 | **Skills** | 3 |
 | **Agents** | 6 |
 | **Instructions** | 9 |
-| **Prompts** | 14 |
+| **Prompts** | 15 |
 | **Templates** | 7 |
-| **Total Assets** | 39 |
+| **Total Assets** | 40 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,8 @@ Review the plan, then type: `confirm`
 | Skill | Purpose | Works In |
 |-------|---------|----------|
 | [**repository-analysis**](.github/skills/repository-analysis/SKILL.md) | Codebase structure & tech stack detection | VS Code, CLI, Claude, Cursor |
-| [**implementation-planning**](.github/skills/implementation-planning/SKILL.md) | Strategic planning & risk mitigation | VS Code, CLI, Claude, Cursor |
 | [**copilot-asset-design**](.github/skills/copilot-asset-design/SKILL.md) | Asset architecture & validation | VS Code, CLI, Claude, Cursor |
 | [**technical-documentation**](.github/skills/technical-documentation/SKILL.md) | Change summaries & API docs | VS Code, CLI, Claude, Cursor |
-| [**deployment-automation**](.github/skills/deployment-automation/SKILL.md) | CI/CD pipelines & deployment strategies | VS Code, CLI, Claude, Cursor |
 
 **Why Skills Matter**: Create once, use everywhere. Same skill works in VS Code, command line, Claude Desktop, or Cursor.
 
@@ -155,23 +153,22 @@ Assets are **tailored to your tech stack** - React, Python, .NET, Go, Rust, PHP,
 
 ## Framework Inventory
 
-### Skills (5)
+### Skills (3)
 Cross-platform capabilities using [agentskills.io](https://agentskills.io) standard.
 
-### Agents (7)
+### Agents (6)
 VS Code workflow orchestration:
 - `BootstrapRepo` - Repository setup entry point
 - `AssetPlanner` - Recommendation engine
 - `AssetGenerator` - Multi-asset creation
-- `HarmonizationAgent` - Cross-reference binding
 - `ChangeExecutor` - File operations
 - `VerificationAgent` - Schema validation
 - `CopilotCustomizer` - Main interactive mode
 
-### Instructions (14)
+### Instructions (9)
 Generation and quality patterns for asset creation.
 
-### Prompts (16)
+### Prompts (15)
 Slash commands for workflows and asset generation.
 
 ### Templates (7)

--- a/SKILLS-MIGRATION.md
+++ b/SKILLS-MIGRATION.md
@@ -22,18 +22,17 @@ CopilotCustomizer has been updated to emphasize **Agent Skills** - the new cross
 ### After (Skills-First)
 - **Agent Skills** as primary capability delivery
 - Cross-platform portable capabilities (agentskills.io standard)
-- **7 agents** (streamlined) + **4 Skills** (portable)
+- **6 agents** (streamlined) + **3 Skills** (portable)
 - Skills + Agents + Instructions + Prompts
 - Multi-platform support (VS Code, CLI, Claude, Cursor, etc.)
 
 ### Agent Reduction
-**Converted 4 agents to Skills** for cross-platform portability:
+**Converted 3 agents to Skills** for cross-platform portability:
 - RepoAnalyzer → **repository-analysis** skill
-- ImplementationPlanner → **implementation-planning** skill  
 - WorkflowValidator → **copilot-asset-design** skill
 - DocumentationGenerator → **technical-documentation** skill
 
-**Result**: 36% fewer agents, improved portability
+**Result**: 45% fewer agents, improved portability
 
 ---
 
@@ -88,7 +87,7 @@ description: What this skill does and when to use it (max 1024 chars)
 
 ## What's New
 
-### New Skills Created (4 skills from agents)
+### New Skills Created (3 skills from agents)
 
 1. **[repository-analysis](.github/skills/repository-analysis/SKILL.md)**
    - Repository structure and pattern analysis
@@ -96,20 +95,14 @@ description: What this skill does and when to use it (max 1024 chars)
    - Dependency mapping strategies
    - **Converted from**: RepoAnalyzer agent
 
-2. **[implementation-planning](.github/skills/implementation-planning/SKILL.md)**
-   - Strategic planning frameworks
-   - Risk mitigation patterns
-   - Validation strategies
-   - **Converted from**: ImplementationPlanner agent
-
-3. **[copilot-asset-design](.github/skills/copilot-asset-design/SKILL.md)**
+2. **[copilot-asset-design](.github/skills/copilot-asset-design/SKILL.md)**
    - Asset architecture patterns
    - Quality validation criteria
    - Integration strategies
    - **Converted from**: WorkflowValidator agent
 
-4. **[technical-documentation](.github/skills/technical-documentation/SKILL.md)**
-   - Documentation generation patterns
+3. **[technical-documentation](.github/skills/technical-documentation/SKILL.md)**
+   - Documentation patterns and generation
    - API documentation templates
    - Change summary formats
    - **Converted from**: DocumentationGenerator agent

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -27,7 +27,7 @@ Comprehensive documentation review and consolidation to improve usability, ensur
 - Clear "Customize Further" examples
 
 **AGENTS.md** - Updated inventory
-- Corrected asset counts (5 skills, 7 agents, 14 instructions, 16 prompts)
+- Corrected asset counts (3 skills, 6 agents, 9 instructions, 15 prompts)
 - Added skills inventory table
 - Updated naming conventions
 - Skills-first strategy documentation
@@ -51,27 +51,27 @@ Comprehensive documentation review and consolidation to improve usability, ensur
 **Updated Asset Counts:**
 | Category | Previous | Current |
 |----------|----------|---------|
-| Skills | 4 | 5 |
-| Agents | 11 (incorrect) | 7 |
-| Instructions | 13 | 14 |
-| Prompts | 18 | 16 |
+| Skills | 5 | 3 |
+| Agents | 7 | 6 |
+| Instructions | 14 | 9 |
+| Prompts | 16 | 15 |
 | Templates | 7 | 7 |
 
 #### Skills Prominence
 - Skills now prominently featured in README.md with dedicated section
-- All 5 skills listed with cross-platform compatibility notes
+- All 3 skills listed with cross-platform compatibility notes
 - Link to agentskills.io standard highlighted throughout
 
 #### Repository Statistics
 
 | Category | Count | Status |
 |----------|-------|--------|
-| **Skills** | 5 | Cross-platform |
-| **Agents** | 7 | VS Code workflow |
-| **Instructions** | 14 | Generation + quality |
-| **Prompts** | 16 | User commands |
+| **Skills** | 3 | Cross-platform |
+| **Agents** | 6 | VS Code workflow |
+| **Instructions** | 9 | Generation + quality |
+| **Prompts** | 15 | User commands |
 | **Templates** | 7 | Document formats |
-| **Total** | 49 | Production-ready |
+| **Total** | 40 | Production-ready |
 
 ---
 


### PR DESCRIPTION
Synchronized all documentation files with actual repository state:

**Corrected Asset Counts:**
- Skills: 3 (was incorrectly listed as 5 in some docs)
- Agents: 6 (was incorrectly listed as 7)
- Instructions: 9 (was incorrectly listed as 14)
- Prompts: 15 (was incorrectly listed as 14 or 16)
- Templates: 7 (correct)
- Total: 40 assets (was listed as 39 or 49)

**Files Updated:**

1. **README.md**
   - Removed non-existent skills (implementation-planning, deployment-automation)
   - Updated Skills section to list only 3 existing skills
   - Corrected Framework Inventory (6 agents, not 7; removed HarmonizationAgent)
   - Fixed prompt count (15, not 16)

2. **AGENTS.md**
   - Updated prompt count from 14 to 15
   - Updated total assets from 39 to 40

3. **.github/ASSETS.md**
   - Updated prompt count from 14 to 15 in overview table
   - Updated total from 39 to 40 in summary

4. **SKILLS-MIGRATION.md**
   - Corrected agent/skill counts (6 agents + 3 skills, not 7+4)
   - Removed reference to non-existent implementation-planning skill
   - Updated agent reduction percentage (45%, not 36%)

5. **docs/changelog/CHANGELOG.md**
   - Updated v1.2 entry with correct asset counts
   - Corrected repository statistics table

**Verification:**
- All 3 skill directories confirmed to exist
- All documentation cross-references validated
- No broken internal links detected

This update ensures documentation accurately reflects the repository state
after the recent merge and consolidation efforts.